### PR TITLE
Add configuration parameter that controls Slack app trigger parameters

### DIFF
--- a/apps/slack-app/src/utils/bot-config.ts
+++ b/apps/slack-app/src/utils/bot-config.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { envVar, isNullOrEmpty } from '@digdir/assistant-lib';
+import { SlackApp, SlackAppSchema, SlackContext, SlackContextSchema } from './slack';
+
+const BotConfigSchema = z.object({
+  ignoreWhenNotTagged: z.boolean().optional(),
+});
+type BotConfig = z.infer<typeof BotConfigSchema>;
+
+const BotConfigDbRowSchema = z.object({
+  id: z.number(),
+  created_at: z.string(),
+  config: z.object(BotConfigSchema.shape),
+  slack_context: z.object(SlackContextSchema.shape),
+  slack_app: z.object(SlackAppSchema.shape),
+});
+type BotConfigDbRow = z.infer<typeof BotConfigDbRowSchema>;
+
+let cachedConfigDb: BotConfigDbRow[] | null = null;
+let configFetchTimestamp: number | null = null;
+
+// create single supabase client
+const supabase: SupabaseClient = createClient(
+  envVar('SLACK_BOT_SUPABASE_URL'),
+  envVar('SLACK_BOT_SUPABASE_API_KEY'),
+);
+
+export async function lookupConfig<T>(
+  app: SlackApp,
+  context: SlackContext,
+  propName: string,
+  defaultValue: T,
+): Promise<T | null> {
+  let merged = {};
+
+  const matching = await fetchConfig(app, context);
+
+  if (matching) {
+    for (let value of matching) {
+      merged = { ...merged, ...value.config };
+    }
+  }
+
+  if (envVar('LOG_LEVEL') == 'debug') {
+    console.log(`lookupConfig, merged result:\n${JSON.stringify(merged)}`);
+  }
+  if (merged && propName in merged) {
+    const configValue = merged[propName as keyof typeof merged] as T;
+    const result = configValue === undefined ? defaultValue : configValue;
+    if (envVar('LOG_LEVEL') == 'debug') {
+      console.log(`lookupConfig found ${propName}: ${result}`);
+    }
+    return result;
+  }
+  return defaultValue;
+}
+
+async function fetchConfig(app: SlackApp, context: SlackContext): Promise<BotConfigDbRow[] | null> {
+  try {
+    if (
+      !cachedConfigDb ||
+      !configFetchTimestamp ||
+      performance.now() - configFetchTimestamp > 10000
+    ) {
+      let { data, error } = await supabase.from('bot_config').select('*');
+      if (error) {
+        console.error('Error fetching bot_config:', error);
+        return null;
+      }
+      cachedConfigDb = data as BotConfigDbRow[];
+    }
+    if (cachedConfigDb) {
+      const matching = matchingConfigDbRows(cachedConfigDb, app, context);
+      return matching;
+    }
+  } catch (error) {
+    console.error('Unexpected error fetching bot_config:', error);
+    return null;
+  }
+  return null;
+}
+
+function matchingConfigDbRows(
+  configDbRows: BotConfigDbRow[],
+  app: SlackApp,
+  context: SlackContext,
+): BotConfigDbRow[] {
+  let matching: BotConfigDbRow[] = [];
+
+  configDbRows.sort(sortBotConfig);
+
+  for (let configDbRow of configDbRows) {
+    if (
+      (isNullOrEmpty(configDbRow.slack_app?.app_id) ||
+        configDbRow.slack_app?.app_id === app.app_id) &&
+      (isNullOrEmpty(configDbRow.slack_context?.channel) ||
+        configDbRow.slack_context?.channel === context.channel) &&
+      (isNullOrEmpty(configDbRow.slack_context?.team) ||
+        configDbRow.slack_context?.team === context.team) &&
+      (isNullOrEmpty(configDbRow.slack_app?.bot_name) ||
+        configDbRow.slack_app?.bot_name == app.bot_name)
+    ) {
+      matching.push(configDbRow);
+    }
+  }
+
+  return configDbRows;
+}
+
+function sortBotConfig(a: BotConfigDbRow, b: BotConfigDbRow) {
+  if (
+    (isNullOrEmpty(a?.slack_app?.bot_name) && !isNullOrEmpty(b?.slack_app?.bot_name)) ||
+    (isNullOrEmpty(a?.slack_app?.app_id) && !isNullOrEmpty(b?.slack_app?.app_id)) ||
+    (isNullOrEmpty(a?.slack_context?.channel) && !isNullOrEmpty(b?.slack_context?.channel)) ||
+    (isNullOrEmpty(a?.slack_context?.team) && !isNullOrEmpty(b?.slack_context?.team))
+  ) {
+    return -1;
+  }
+
+  if (
+    (isNullOrEmpty(b?.slack_app?.bot_name) && !isNullOrEmpty(a?.slack_app?.bot_name)) ||
+    (isNullOrEmpty(b?.slack_app?.app_id) && !isNullOrEmpty(a?.slack_app?.app_id)) ||
+    (isNullOrEmpty(b?.slack_context?.channel) && !isNullOrEmpty(a?.slack_context?.channel)) ||
+    (isNullOrEmpty(b?.slack_context?.team) && !isNullOrEmpty(a?.slack_context?.team))
+  ) {
+    return 1;
+  }
+  return 0;
+}

--- a/apps/slack-app/src/utils/bot-log.ts
+++ b/apps/slack-app/src/utils/bot-log.ts
@@ -1,10 +1,11 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { SlackContext } from './slack';
+import { SlackApp, SlackContext } from './slack';
 import { envVar } from '@digdir/assistant-lib';
 import { Data } from 'dataclass';
 
 export class BotLogEntry extends Data {
   slack_context?: SlackContext | null = null;
+  slack_app?: SlackApp | null = null;
   elapsed_ms: number = 0;
   step_name: string = '';
   payload?: any | null = null;
@@ -35,10 +36,16 @@ export async function botLog(entry: BotLogEntry) {
   return insertResponse;
 }
 
-export async function updateReactions(slackContext: SlackContext, reactions: any) {
+export async function updateReactions(
+  slackApp: SlackApp,
+  slackContext: SlackContext,
+  reactions: any,
+) {
   const ts = slackContext.ts;
   const channel = slackContext.channel;
   // retrieve the correct row, looking for slackContext.ts in the slackContext column, which is jsonb type
+
+  // TODO: match on slack_app as well
   const resultSet = await supabase
     .from('bot_log')
     .select('*')

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   ],
   "scripts": {
     "clean": "rimraf packages/assistant-lib/dist/ && rimraf apps/slack-app/dist/",
-    "build:assistant-lib": " tsc -p ./packages/assistant-lib/",
-    "build:slack-app": "tsc -p ./apps/slack-app/",
+    "prettier": "prettier packages/assistant-lib/src/ --write && prettier ./apps/slack-app/src/ --write",
+    "build:assistant-lib": "prettier ./packages/assistant-lib/src/ --write && tsc -p ./packages/assistant-lib/",
+    "build:slack-app": "prettier ./apps/slack-app/src/ --write && tsc -p ./apps/slack-app/",
     "build": "yarn clean && yarn build:assistant-lib && yarn build:slack-app",
     "run:slack-app": "node ./apps/slack-app/dist/src/app.js"
   },
@@ -16,6 +17,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "prettier": "^3.2.5",
     "rimraf": "^5.0.5"
   }
 }

--- a/packages/assistant-lib/src/docs/prompts.ts
+++ b/packages/assistant-lib/src/docs/prompts.ts
@@ -35,7 +35,6 @@ Question: {question}
     translate_hint +
     "\nHelpful answer:\n";
 
-  console.log(`Prompt text:\n${prompt_text}`);
   return prompt_text;
 }
 

--- a/packages/assistant-lib/src/docs/query-relaxation.ts
+++ b/packages/assistant-lib/src/docs/query-relaxation.ts
@@ -35,7 +35,7 @@ export async function queryRelaxation(
     For example, include queries like ['keyword_1 keyword_2', 'keyword_1', 'keyword_2'].
     Be creative. The more queries you include, the more likely you are to find relevant results.`;
 
-  if (envVar("USE_AZURE_OPENAI_API", false) == 'true') {
+  if (envVar("USE_AZURE_OPENAI_API", false) == "true") {
     //         query_result = await azureClient.chat.completions.create({
     //             model: envVar('AZURE_OPENAI_DEPLOYMENT'),
     //             response_model: { schema: SearchQueriesSchema, name: "GeneratedSearchQueries" },

--- a/packages/assistant-lib/src/docs/rag.ts
+++ b/packages/assistant-lib/src/docs/rag.ts
@@ -263,7 +263,7 @@ export async function ragPipeline(
     .replace("{question}", user_input);
 
   if (typeof stream_callback_msg1 !== "function") {
-    if (envVar("USE_AZURE_OPENAI_API") === 'true') {
+    if (envVar("USE_AZURE_OPENAI_API") === "true") {
       // const chatResponse = await azureClient.chat.completions.create({
       //     model: envVar('AZURE_OPENAI_DEPLOYMENT'),
       //     temperature: 0.1,

--- a/packages/assistant-lib/src/docs/translate.ts
+++ b/packages/assistant-lib/src/docs/translate.ts
@@ -27,7 +27,7 @@ export async function translate(
   if (typeof stream_callback === "function") {
     translated = await chat_stream(messages, stream_callback);
   } else {
-    if (envVar("USE_AZURE_OPENAI_API") === 'true') {
+    if (envVar("USE_AZURE_OPENAI_API") === "true") {
       // query_result = await azureLlm.chat.completions.create({
       //   model: envVar('AZURE_OPENAI_DEPLOYMENT'),
       //   temperature: 0.1,

--- a/packages/assistant-lib/src/index.ts
+++ b/packages/assistant-lib/src/index.ts
@@ -2,3 +2,4 @@ export * from "./docs/analysis";
 export * from "./docs/rag";
 export * from "./markdown";
 export * from "./general";
+export * from "./schema";

--- a/packages/assistant-lib/src/llm.ts
+++ b/packages/assistant-lib/src/llm.ts
@@ -82,7 +82,7 @@ export async function chat_stream(
 
   let llm_client: OpenAI;
 
-  if (envVar("USE_AZURE_OPENAI_API") === 'true') {
+  if (envVar("USE_AZURE_OPENAI_API") === "true") {
     console.error("WHY ARE YOU HERE?");
     // console.log(`chat_stream - azure deployment: ${envVar('AZURE_OPENAI_DEPLOYMENT')}`);
 

--- a/packages/assistant-lib/src/markdown.ts
+++ b/packages/assistant-lib/src/markdown.ts
@@ -1,3 +1,5 @@
+import { envVar } from "./general";
+
 const blockToken = "```";
 const sectionDelimiter = "\n\n";
 
@@ -20,7 +22,9 @@ export function splitToSections(markdown: string | null): string[] {
     if (hasOpenCodeBlock(sections[i])) {
       let a = i + 1;
       while (hasOpenCodeBlock(sections[i]) && a <= sections.length - 1) {
-        console.log(`Merging section ${i} and ${a}`);
+        if (envVar("LOG_LEVEL") == "debug") {
+          console.log(`Merging section ${i} and ${a}`);
+        }
         sections[i] =
           (sections[i] || "") + sectionDelimiter + (sections[a] || "");
         sections[a] = "";

--- a/packages/assistant-lib/src/schema.ts
+++ b/packages/assistant-lib/src/schema.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export interface ZSchemaInterface<
+  T extends z.ZodRawShape,
+  TObject = z.ZodObject<T>,
+> {
+  new (data: z.infer<z.ZodObject<T>>): z.infer<z.ZodObject<T>>;
+
+  schema: TObject;
+
+  parse<
+    TFinal extends new (data: z.infer<z.ZodObject<T>>) => InstanceType<TFinal>,
+  >(
+    this: TFinal,
+    value: z.infer<z.ZodObject<T>>,
+  ): InstanceType<TFinal>;
+}
+
+export function ZSchema<
+  T extends z.ZodRawShape,
+  Type = ZSchemaInterface<T> & z.infer<z.ZodObject<T>>,
+>(schema: z.ZodObject<T>): Type {
+  const res = class {
+    static schema = schema;
+    constructor(value: z.infer<z.ZodObject<T>>) {
+      // console.log(`ZSchema constructor - type: ${JSON.stringify(schema)}  value: ${JSON.stringify(value)}`);
+      Object.assign(this, schema.parse(value));
+    }
+    static parse<T extends typeof res>(this: T, value: unknown): any {
+      const parsed = new this(schema.parse(value)) as any;
+      return parsed;
+    }
+  };
+  return res as typeof res & any;
+}


### PR DESCRIPTION
When the parameter is set, the bot should ignore all thread starter messages that do not specifically tag the bot. 

Added general configuration support in this PR as well, see #17 

