### PR TITLE
Feature/channel prompts

### DIFF
--- a/apps/admin/src/components/BotReplyMetadata.tsx
+++ b/apps/admin/src/components/BotReplyMetadata.tsx
@@ -81,7 +81,7 @@ const BotReplyDetails: React.FC<BotReplyDetailsProps> = ({ message }) => {
               {message?.reactions?.map((query: Reaction, index: number) => (
                 <li key={query.name}>
                   <pre>
-                  {query.name}  ({query.count})
+                    {query.name} ({query.count})
                   </pre>
                 </li>
               ))}

--- a/apps/admin/src/components/RagPromptView.tsx
+++ b/apps/admin/src/components/RagPromptView.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Link, Box } from "@mui/material";
+import ReactMarkdown from "react-markdown";
+import { LightAsync as SyntaxHighlighter } from "react-syntax-highlighter";
+import { github } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { DocsBotReplyMessage } from "../models/Models";
+import ErrorBoundary from "./ErrorBoundary";
+
+export type Params = DocsBotReplyMessage & {};
+
+const RagSourceView: React.FC<Params> = ({ message }) => {
+  const components = {
+    code({ node, inline, className, children, ...props }) {
+      const match = /language-(\w+)/.exec(className || "");
+      return !inline && match ? (
+        <SyntaxHighlighter
+          children={String(children).replace(/\n$/, "")}
+          style={github}
+          language={match[1]}
+          PreTag="div"
+          {...props}
+        />
+      ) : (
+        <code className={className} {...props}>
+          {children}
+        </code>
+      );
+    },
+  };
+
+  return (
+    <Box sx={{ flexWrap: "wrap" }}>
+      <React.Fragment>
+        <ErrorBoundary>
+          {" "}
+          <ul>
+            {Object.entries(message?.content?.prompts || {}).map(
+              ([key, value], index) => (
+                <li key={key}>
+                  <Box flexDirection="column">
+                    <span>
+                      Prompt #{index + 1}: {key}
+                    </span>
+                    <ReactMarkdown components={components}>
+                      {value}
+                    </ReactMarkdown>
+                  </Box>
+                  <hr />
+                </li>
+              ),
+            )}
+          </ul>
+        </ErrorBoundary>
+      </React.Fragment>
+    </Box>
+  );
+};
+
+export default RagSourceView;

--- a/apps/admin/src/components/ThreadViewPane.tsx
+++ b/apps/admin/src/components/ThreadViewPane.tsx
@@ -3,10 +3,10 @@ import { Link, List, ListItem, Box, Tab } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 import { Props, Message } from "../models/Models";
 import { useThreadReplies } from "../hooks/useThreadReplies";
-import { RagPipelineResult } from "@digdir/assistants";
 import BotReplyContent from "./BotReplyContent";
 import BotReplyMetadata from "./BotReplyMetadata";
 import RagSourceView from "./RagSourceView";
+import RagPromptView from "./RagPromptView";
 
 const ThreadViewPane: React.FC<Props> = ({
   channelId,
@@ -55,6 +55,7 @@ const ThreadViewPane: React.FC<Props> = ({
             <Tab label="English" value="english" />
             <Tab label="Original" value="original" />
             <Tab label="Sources" value="sources" />
+            <Tab label="Prompts" value="prompts" />
           </TabList>
         </Box>
         <TabPanel value="english" style={{ padding: "0px 8px" }}>
@@ -93,6 +94,9 @@ const ThreadViewPane: React.FC<Props> = ({
         </TabPanel>
         <TabPanel value="sources" style={{ padding: "0px 8px" }}>
           <RagSourceView message={threadMessages[0]} />
+        </TabPanel>
+        <TabPanel value="prompts" style={{ padding: "0px 8px" }}>
+          <RagPromptView message={threadMessages[0]} />
         </TabPanel>
       </TabContext>
     </Box>

--- a/apps/admin/src/models/Models.ts
+++ b/apps/admin/src/models/Models.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { RagPipelineResult } from "@digdir/assistant-lib"
 
 const ReactionSchema = z.object({
   name: z.string(),
@@ -39,23 +40,6 @@ const DocsUserQuerySchema = z.object({
   content_category: z.string(),
 });
 export type DocsUserQuery = z.infer<typeof DocsUserQuerySchema>;
-
-const RagPipelineResultSchema = z.object({
-  original_user_query: z.string(),
-  english_user_query: z.string(),
-  user_query_language_name: z.string(),
-  english_answer: z.string(),
-  translated_answer: z.string(),
-  rag_success: z.boolean(),
-  search_queries: z.array(z.string()),
-  source_urls: z.array(z.string()),
-  source_documents: z.array(z.any()), // Assuming we don't have a specific structure for documents
-  relevant_urls: z.array(z.string()),
-  not_loaded_urls: z.array(z.string()),
-  durations: z.record(z.string(), z.number()), // Assuming durations is an object with string keys and number values
-});
-
-export type RagPipelineResult = z.infer<typeof RagPipelineResultSchema>;
 
 export type RagPipelineMessage = Message & {
   content: RagPipelineResult;

--- a/apps/slack-app/package.json
+++ b/apps/slack-app/package.json
@@ -10,7 +10,7 @@
     "codestyle:check": "prettier src/ --check",
     "codestyle:fix": "prettier src/ --write",
     "build": "tsc -p .",
-    "watch": "nodemon src/app.ts",
+    "dev": "nodemon src/app.ts",
     "start": "node dist/src/app.js",
     "go": "yarn run build && yarn start"
   },

--- a/apps/slack-app/src/app.ts
+++ b/apps/slack-app/src/app.ts
@@ -92,6 +92,20 @@ app.message(async ({ message, say }) => {
     true,
   );
 
+  const channelQueryRelaxPrompt = await lookupConfig(
+    slackApp,
+    srcEvtContext,
+    'channelQueryRelaxPrompt',
+    '',
+  );
+
+  const channelRagPrompt = await lookupConfig(
+    slackApp,
+    srcEvtContext,
+    'channelRagPrompt',
+    '',
+  );
+
   if (envVar('LOG_LEVEL') == 'debug') {
     console.log(`slackApp:\n${JSON.stringify(slackApp)}`);
     console.log(`slackContext:\n${JSON.stringify(srcEvtContext)}`);
@@ -259,6 +273,8 @@ app.message(async ({ message, say }) => {
     ragResponse = await ragPipeline(
       stage1Result.questionTranslatedToEnglish,
       stage1Result.userInputLanguageName,
+      channelQueryRelaxPrompt || '',
+      channelRagPrompt || '',
       updateSlackMsgCallback(app, firstThreadTs),
       translatedMsgCallback,
     );

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:assistant-lib": "cd packages/assistant-lib && yarn codestyle:fix && yarn build && cd ../..",
     "build:slack-app": "cd apps/slack-app && yarn codestyle:fix && yarn build && cd ../..",
     "build:admin": "cd apps/admin && yarn codestyle:fix && yarn build && cd ../..",
-    "build": "export && yarn clean && yarn build:assistant-lib && yarn build:admin && yarn build:slack-app",
+    "build": "yarn clean && yarn build:assistant-lib && yarn build:admin && yarn build:slack-app",
     "run:slack-app": "node ./apps/slack-app/dist/src/app.js"
   },
   "devDependencies": {

--- a/packages/assistant-lib/src/docs/prompts.ts
+++ b/packages/assistant-lib/src/docs/prompts.ts
@@ -19,14 +19,14 @@ Catch all category if none of the above categories matches well.
 3. Finally, return the category, original language code and name.
 `;
 
-export function qaTemplate(channelRagPrompt: string = "") {
+export function qaTemplate(promptRagGenerate: string = "") {
   const translate_hint =
     "\nOnly return the helpful answer below, along with relevant source code examples when possible.\n";
 
   const prompt_text =
     `Use the following pieces of information to answer the user's question.
 If you don't know the answer, just say that you don't know, don't try to make up an answer.
-${channelRagPrompt}
+${promptRagGenerate}
 
 Context: {context}
 

--- a/packages/assistant-lib/src/docs/prompts.ts
+++ b/packages/assistant-lib/src/docs/prompts.ts
@@ -19,13 +19,14 @@ Catch all category if none of the above categories matches well.
 3. Finally, return the category, original language code and name.
 `;
 
-export function qaTemplate() {
+export function qaTemplate(channelRagPrompt: string = "") {
   const translate_hint =
     "\nOnly return the helpful answer below, along with relevant source code examples when possible.\n";
 
   const prompt_text =
     `Use the following pieces of information to answer the user's question.
 If you don't know the answer, just say that you don't know, don't try to make up an answer.
+${channelRagPrompt}
 
 Context: {context}
 

--- a/packages/assistant-lib/src/docs/query-relaxation.ts
+++ b/packages/assistant-lib/src/docs/query-relaxation.ts
@@ -24,6 +24,7 @@ export type QueryRelaxation = z.infer<typeof QueryRelaxationSchema> | null;
 
 export async function queryRelaxation(
   user_input: string,
+  channelQueryRelaxPrompt: string = "",
 ): Promise<QueryRelaxation> {
   let query_result: QueryRelaxation | null = null;
 
@@ -33,7 +34,9 @@ export async function queryRelaxation(
     Use a variation of related keywords and synonyms for the queries, trying to be as general as possible.
     Include as many queries as you can think of, including and excluding terms.
     For example, include queries like ['keyword_1 keyword_2', 'keyword_1', 'keyword_2'].
-    Be creative. The more queries you include, the more likely you are to find relevant results.`;
+    Be creative. The more queries you include, the more likely you are to find relevant results.
+    
+    ${channelQueryRelaxPrompt}`;
 
   if (envVar("USE_AZURE_OPENAI_API", false) == "true") {
     //         query_result = await azureClient.chat.completions.create({
@@ -52,6 +55,9 @@ export async function queryRelaxation(
     console.log(
       `${stage_name} model name: ${envVar("OPENAI_API_MODEL_NAME", "")}`,
     );
+    if (envVar("LOG_LEVEL") == "debug") {
+      console.log(`query relax prompt: \n${prompt}`);
+    }
     query_result = await openaiClientInstance.chat.completions.create({
       model: envVar("OPENAI_API_MODEL_NAME"),
       response_model: {

--- a/packages/assistant-lib/src/docs/query-relaxation.ts
+++ b/packages/assistant-lib/src/docs/query-relaxation.ts
@@ -18,25 +18,18 @@ const openaiClientInstance = Instructor({
 
 const QueryRelaxationSchema = z.object({
   searchQueries: z.array(z.string()),
+  promptUsed: z.string(),
 });
 
 export type QueryRelaxation = z.infer<typeof QueryRelaxationSchema> | null;
 
 export async function queryRelaxation(
   user_input: string,
-  channelQueryRelaxPrompt: string = "",
+  promptRagQueryRelax: string = "",
 ): Promise<QueryRelaxation> {
   let query_result: QueryRelaxation | null = null;
 
-  const prompt = `You have access to a search API that returns relevant documentation.
-
-    Your task is to generate an array of up to 7 search queries that are relevant to this question. 
-    Use a variation of related keywords and synonyms for the queries, trying to be as general as possible.
-    Include as many queries as you can think of, including and excluding terms.
-    For example, include queries like ['keyword_1 keyword_2', 'keyword_1', 'keyword_2'].
-    Be creative. The more queries you include, the more likely you are to find relevant results.
-    
-    ${channelQueryRelaxPrompt}`;
+  const prompt = promptRagQueryRelax;
 
   if (envVar("USE_AZURE_OPENAI_API", false) == "true") {
     //         query_result = await azureClient.chat.completions.create({
@@ -56,7 +49,7 @@ export async function queryRelaxation(
       `${stage_name} model name: ${envVar("OPENAI_API_MODEL_NAME", "")}`,
     );
     if (envVar("LOG_LEVEL") == "debug") {
-      console.log(`query relax prompt: \n${prompt}`);
+      console.log(`prompt.rag.queryRelax: \n${prompt}`);
     }
     query_result = await openaiClientInstance.chat.completions.create({
       model: envVar("OPENAI_API_MODEL_NAME"),

--- a/packages/assistant-lib/src/docs/retrieval-typesense.ts
+++ b/packages/assistant-lib/src/docs/retrieval-typesense.ts
@@ -2,7 +2,7 @@ import Typesense from "typesense";
 import { CollectionCreateSchema } from "typesense/lib/Typesense/Collections";
 import { QueryRelaxation } from "./query-relaxation";
 import { typesenseConfig } from "../config/typesense";
-import { envVar as env_var } from "../general";
+import { envVar } from "../general";
 import { flatMap } from "remeda";
 
 const typesenseCfg = typesenseConfig();
@@ -23,7 +23,7 @@ export async function searchMultiple(relaxedQueries: QueryRelaxation) {
 
   const multiSearchArgs = {
     searches: relaxedQueries.searchQueries.map((query) => ({
-      collection: env_var("TYPESENSE_DOCS_COLLECTION"),
+      collection: envVar("TYPESENSE_DOCS_COLLECTION"),
       q: query,
       query_by: "content,embedding",
       include_fields:
@@ -52,7 +52,7 @@ export async function lookupSearchPhrasesSimilar(
 
   const multiSearchArgs = {
     searches: relaxedQueries.searchQueries.map((query) => ({
-      collection: env_var("TYPESENSE_DOCS_SEARCH_PHRASE_COLLECTION"),
+      collection: envVar("TYPESENSE_DOCS_SEARCH_PHRASE_COLLECTION"),
       q: query,
       query_by: "search_phrase,phrase_vec",
       include_fields: "search_phrase,url",
@@ -66,6 +66,12 @@ export async function lookupSearchPhrasesSimilar(
   };
 
   const response = await client.multiSearch.perform(multiSearchArgs, {});
+
+  if (envVar("LOG_LEVEL") === "debug") {
+    console.log(
+      `lookupSearchPhraseSimilar results:\n${JSON.stringify(response)}`,
+    );
+  }
 
   const searchPhraseHits = flatMap(response.results, (result: any) =>
     flatMap(result.grouped_hits, (group: any) => group.hits),
@@ -96,7 +102,7 @@ export async function retrieveAllUrls(page: number, pageSize: number) {
   const multiSearchArgs = {
     searches: [
       {
-        collection: env_var("TYPESENSE_DOCS_COLLECTION"),
+        collection: envVar("TYPESENSE_DOCS_COLLECTION"),
         q: "*",
         query_by: "url_without_anchor",
         include_fields: "url_without_anchor,content_markdown,id",
@@ -117,7 +123,7 @@ export async function retrieveAllByUrl(urlList: RankedUrl[]) {
   const client = new Typesense.Client(typesenseCfg);
 
   const urlSearches = urlList.slice(0, 20).map((rankedUrl) => ({
-    collection: env_var("TYPESENSE_DOCS_COLLECTION"),
+    collection: envVar("TYPESENSE_DOCS_COLLECTION"),
     q: rankedUrl["url"],
     query_by: "url_without_anchor",
     include_fields:
@@ -174,7 +180,7 @@ async function setupSearchPhraseSchema(collectionNameTmp: string) {
 async function lookupSearchPhrases(url: string, collectionName?: string) {
   const client = new Typesense.Client(typesenseCfg);
   if (!collectionName) {
-    collectionName = env_var("TYPESENSE_DOCS_SEARCH_PHRASE_COLLECTION");
+    collectionName = envVar("TYPESENSE_DOCS_SEARCH_PHRASE_COLLECTION");
   }
 
   const multiSearchArgs = {

--- a/packages/assistant-lib/src/index.ts
+++ b/packages/assistant-lib/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./docs/analysis";
 export * from "./docs/rag";
+export * from "./docs/prompts";
 export * from "./markdown";
 export * from "./general";
 export * from "./schema";


### PR DESCRIPTION
Allow the Assistant administrator to add additional context information to RAG prompts for specific Slack workspaces, channels or apps.

Additionally, store the specific prompts used in the database and display them in the admin UI.