### PR TITLE
Improve handling of translated messages

### DIFF
--- a/apps/admin/src/components/BotReplyMetadata.tsx
+++ b/apps/admin/src/components/BotReplyMetadata.tsx
@@ -28,10 +28,10 @@ const BotReplyDetails: React.FC<BotReplyDetailsProps> = ({ message }) => {
             <Tab label="Sources" value="sources" />
             <Tab label="Phrases" value="phrases" />
             <Tab
-              label={"Durations (" + message?.durations?.total.toFixed(1) + ")"}
+              label={"Durations (" + message?.durations?.total?.toFixed(1) + ")"}
               value="durations"
             />
-            <Tab label="Reactions" value="reactions" />
+            <Tab label={"Reactions (" + message?.reactions?.length + ")"} value="reactions" />
           </TabList>
         </Box>
 

--- a/apps/admin/src/models/Models.ts
+++ b/apps/admin/src/models/Models.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { RagPipelineResult } from "@digdir/assistant-lib"
+import { RagPipelineResult } from "@digdir/assistant-lib";
 
 const ReactionSchema = z.object({
   name: z.string(),

--- a/apps/slack-app/src/utils/bot-log.ts
+++ b/apps/slack-app/src/utils/bot-log.ts
@@ -42,38 +42,44 @@ const supabase: SupabaseClient = createClient(
 );
 
 export async function botLog(entry: BotLogEntry) {
-  const slackMessage: SlackMessage = {
-    team_id: entry.slack_context?.team_id || '',
-    team_name: entry.slack_context?.team_name || '',
-    channel_id: entry.slack_context?.channel_id || '',
-    channel_name: entry.slack_context?.channel_name || '',
-    channel_type: entry.slack_context?.channel_type || '',
-    user_id: entry.slack_context?.user_id || '',
-    user_name: entry.slack_context?.user_name || '',
-    user_type: entry.slack_context?.user_type || '',
-    ts_date: entry.slack_context?.ts_date || 0,
-    ts_time: entry.slack_context?.ts_time || 0,
-    thread_ts_date: entry.slack_context?.thread_ts_date,
-    thread_ts_time: entry.slack_context?.thread_ts_time,
-    content: entry.content,
-    content_type: entry.content_type,
-    bot_name: entry.slack_app?.bot_name || '',
-    step_name: entry.step_name || '',
-    durations: entry.durations,
-  };
+  try {
+    const slackMessage: SlackMessage = {
+      team_id: entry.slack_context?.team_id || '',
+      team_name: entry.slack_context?.team_name || '',
+      channel_id: entry.slack_context?.channel_id || '',
+      channel_name: entry.slack_context?.channel_name || '',
+      channel_type: entry.slack_context?.channel_type || '',
+      user_id: entry.slack_context?.user_id || '',
+      user_name: entry.slack_context?.user_name || '',
+      user_type: entry.slack_context?.user_type || '',
+      ts_date: entry.slack_context?.ts_date || 0,
+      ts_time: entry.slack_context?.ts_time || 0,
+      thread_ts_date: entry.slack_context?.thread_ts_date,
+      thread_ts_time: entry.slack_context?.thread_ts_time,
+      content: entry.content,
+      content_type: entry.content_type,
+      bot_name: entry.slack_app?.bot_name || '',
+      step_name: entry.step_name || '',
+      durations: entry.durations,
+    };
 
-  const functionUrl = envVar('SLACK_APP_SUPABASE_API_URL') + '/functions/v1/log_slack_message';
-  const functionResponse = await fetch(functionUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      apikey: envVar('SLACK_APP_SUPABASE_ANON_KEY'),
-    },
-    body: JSON.stringify(slackMessage),
-  });
-  if (!functionResponse.ok) {
-    console.error(`Function call failed with status ${functionResponse.status}`);
-    return null;
+    const functionUrl = envVar('SLACK_APP_SUPABASE_API_URL') + '/functions/v1/log_slack_message';
+    const functionResponse = await fetch(functionUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: envVar('SLACK_APP_SUPABASE_ANON_KEY'),
+      },
+      body: JSON.stringify(slackMessage),
+    });
+    if (!functionResponse.ok) {
+      console.error(
+        `Call to 'log_slack_message' failed with status ${functionResponse.status}, message: ${functionResponse.statusText}\nPayload:\n${JSON.stringify(entry)}`,
+      );
+      return;
+    }
+  } catch (error) {
+    console.error('Error in botLog:', error);
   }
 
   return;

--- a/apps/slack-app/src/utils/slack.ts
+++ b/apps/slack-app/src/utils/slack.ts
@@ -73,7 +73,7 @@ export async function getEventContext(
     `getEventContext: channel_type: ${evt.channel_type}. channel_name: ${channel_name}, team_name: ${team_name}`,
   );
 
-  const context = new SlackContext({
+  const slackContext = {
     ts_date,
     ts_time,
     thread_ts_date,
@@ -87,8 +87,8 @@ export async function getEventContext(
     user_name,
     user_type: 'human',
     time_utc: tsToTimestamptz(evt.ts),
-  });
-  return context;
+  };
+  return SlackContext.parse(slackContext);
 }
 
 export async function getChatUpdateContext(


### PR DESCRIPTION
When the final reply should be translated, skip streaming the English reply and call finalizeAnswer only once.

- also fixes issue with multiple calls to finalizeMessage and errors in botLog
- add reaction count to tab label
