### PR TITLE
Convert markdown to Slack mrkdwn format

### DIFF
--- a/apps/slack-app/package.json
+++ b/apps/slack-app/package.json
@@ -21,6 +21,7 @@
     "@instructor-ai/instructor": "^0.0.7",
     "@slack/bolt": "^3.17.1",
     "@supabase/supabase-js": "^2.39.8",
+    "@tryfabric/mack": "^1.2.1",
     "@types/ramda": "^0.30.0",
     "axios": "^1.6.8",
     "dataclass": "^2.1.1",

--- a/apps/slack-app/src/app.ts
+++ b/apps/slack-app/src/app.ts
@@ -524,13 +524,6 @@ function updateSlackMsgCallback(
 
     const blocks = await markdownToBlocks(contentChunks.join(''));
 
-
-    // const sections = splitToSections(contentChunks.join(''));
-
-    // const blocks = sections.map((paragraph, i) => {
-    //   return markdownToBlocks(paragraph);
-    // });
-
     if (envVar('LOG_LEVEL') == 'debug') {
       console.log(
         `Partial response update for channel '${threadTs.channel}' ts ${
@@ -569,17 +562,6 @@ async function finalizeAnswer(
   const relevantSources = ragResponse.relevant_urls;
 
   const blocks = await markdownToBlocks(translation ? ragResponse.translated_answer : ragResponse.english_answer);
-
-  // const sections = splitToSections(
-  //   translation ? ragResponse.translated_answer : ragResponse.english_answer,
-  // );
-
-  // const blocks: any[] = sections
-  //   .filter((section) => !isNullOrEmpty(section))
-  //   .map((paragraph, i) => ({
-  //     type: 'section',
-  //     text: { type: 'mrkdwn', text: paragraph },
-  //   }));
 
   if (relevantSources.length > 0) {
     const linksMarkdown = relevantSources

--- a/apps/slack-app/src/app.ts
+++ b/apps/slack-app/src/app.ts
@@ -22,6 +22,7 @@ import { botLog, BotLogEntry, updateReactions } from './utils/bot-log';
 import OpenAI from 'openai';
 import { isNumber } from 'remeda';
 import { RagPipelineResult } from '@digdir/assistant-lib';
+import {markdownToBlocks} from '@tryfabric/mack';
 
 const expressReceiver = new ExpressReceiver({
   signingSecret: envVar('SLACK_BOT_SIGNING_SECRET'),
@@ -521,12 +522,14 @@ function updateSlackMsgCallback(
 
     contentChunks.push(partialResponse);
 
-    const sections = splitToSections(contentChunks.join(''));
+    const blocks = await markdownToBlocks(contentChunks.join(''));
 
-    const blocks = sections.map((paragraph, i) => ({
-      type: 'section',
-      text: { type: 'mrkdwn', text: paragraph },
-    }));
+
+    // const sections = splitToSections(contentChunks.join(''));
+
+    // const blocks = sections.map((paragraph, i) => {
+    //   return markdownToBlocks(paragraph);
+    // });
 
     if (envVar('LOG_LEVEL') == 'debug') {
       console.log(
@@ -565,16 +568,18 @@ async function finalizeAnswer(
 
   const relevantSources = ragResponse.relevant_urls;
 
-  const sections = splitToSections(
-    translation ? ragResponse.translated_answer : ragResponse.english_answer,
-  );
+  const blocks = await markdownToBlocks(translation ? ragResponse.translated_answer : ragResponse.english_answer);
 
-  const blocks: any[] = sections
-    .filter((section) => !isNullOrEmpty(section))
-    .map((paragraph, i) => ({
-      type: 'section',
-      text: { type: 'mrkdwn', text: paragraph },
-    }));
+  // const sections = splitToSections(
+  //   translation ? ragResponse.translated_answer : ragResponse.english_answer,
+  // );
+
+  // const blocks: any[] = sections
+  //   .filter((section) => !isNullOrEmpty(section))
+  //   .map((paragraph, i) => ({
+  //     type: 'section',
+  //     text: { type: 'mrkdwn', text: paragraph },
+  //   }));
 
   if (relevantSources.length > 0) {
     const linksMarkdown = relevantSources

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,7 +969,7 @@
     p-queue "^2.4.2"
     ws "^7.5.3"
 
-"@slack/types@^2.11.0", "@slack/types@^2.9.0":
+"@slack/types@^2.1.0", "@slack/types@^2.11.0", "@slack/types@^2.9.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.11.0.tgz#948c556081c3db977dfa8433490cc2ff41f47203"
   integrity sha512-UlIrDWvuLaDly3QZhCPnwUSI/KYmV1N9LyhuH6EDKCRS1HWZhyTG3Ja46T3D0rYfqdltKYFXbJSSRPwZpwO0cQ==
@@ -1135,6 +1135,15 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@tryfabric/mack@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@tryfabric/mack/-/mack-1.2.1.tgz#21a2916466c93c76ce644cb41401e6bfa4bb5f06"
+  integrity sha512-qQKj3l4x/7fWPHyk3zO3hPK2NUTH8AINJnVbdBYforWpm+6RDzp22gFIE66BJd2z7EFmt7F9aUOyZTKwmxiXrA==
+  dependencies:
+    "@slack/types" "^2.1.0"
+    fast-xml-parser "^4.0.6"
+    marked "^4.0.12"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -2777,6 +2786,13 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-xml-parser@^4.0.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz#190f9d99097f0c8f2d3a0e681a10404afca052ff"
+  integrity sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==
+  dependencies:
+    strnum "^1.0.5"
+
 fastq@^1.6.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
@@ -3791,6 +3807,11 @@ make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
+marked@^4.0.12:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 md5@^2.3.0:
   version "2.3.0"
@@ -5189,6 +5210,11 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 style-to-object@^1.0.0:
   version "1.0.6"


### PR DESCRIPTION
Use the `@tryfabric/mack` library to convert to Slack mrkdwn format.

## Related Issue(s)
- #32 

