### PR TITLE
Chore/add express explicit dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# build image - START
 # args without default values
 FROM node as builder
 ARG VITE_SLACK_APP_SUPABASE_API_URL=default \
@@ -8,9 +9,6 @@ USER root
 RUN corepack enable yarn \
     && yarn policies set-version $YARN_VERSION
 
-# switch back to non-root user
-USER node
-
 # Create app directory
 WORKDIR /usr/src/app
 
@@ -20,17 +18,14 @@ COPY apps/ ./apps/
 COPY packages/ ./packages/
 COPY package.json yarn.lock ./
 
-# important to preview env var with VITE so that is included in the build artifact
+# important to prefix envvar with 'VITE_' so that is included in the build artifact
 ENV VITE_SLACK_APP_SUPABASE_API_URL=$VITE_SLACK_APP_SUPABASE_API_URL
 ENV VITE_SLACK_APP_SUPABASE_ANON_KEY=$VITE_SLACK_APP_SUPABASE_ANON_KEY
-
-
-# DEBUG: print environment vars
-# RUN export
 
 RUN yarn install
 RUN yarn build
 
+# production image - START
 FROM node:slim as runner
 
 ENV NODE_ENV production

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,6 @@ RUN yarn build
 FROM node:slim as runner
 
 ENV NODE_ENV production
-ENV YARN_VERSION 4.2.2
-USER root
-RUN corepack enable yarn \
-    && yarn policies set-version $YARN_VERSION
 
 # switch back to non-root user    
 USER node
@@ -46,12 +42,7 @@ USER node
 WORKDIR /usr/src/app
 
 # Install app dependencies
-COPY .yarn ./.yarn
-COPY package.json yarn.lock ./
-
-RUN yarn workspaces focus --production
-
 COPY --from=builder /usr/src/app/ .
 
 EXPOSE 3000
-CMD export; yarn run:slack-app
+CMD node ./apps/slack-app/dist/src/app.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ USER root
 RUN corepack enable yarn \
     && yarn policies set-version $YARN_VERSION
 
+# switch back to non-root user
+USER node
+
 # Create app directory
 WORKDIR /usr/src/app
 
@@ -36,6 +39,9 @@ USER root
 RUN corepack enable yarn \
     && yarn policies set-version $YARN_VERSION
 
+# switch back to non-root user    
+USER node
+
 # Create app directory
 WORKDIR /usr/src/app
 
@@ -48,5 +54,4 @@ RUN yarn workspaces focus --production
 COPY --from=builder /usr/src/app/ .
 
 EXPOSE 3000
-USER node
 CMD export; yarn run:slack-app


### PR DESCRIPTION
Yarn 4 is implements a stricter policy when resolving Node built-in modules. In this case, we need to add a reference to Express.

This PR also improves the multi-stage build to remove the need for yarn entirely in the `runner` image.